### PR TITLE
Use flake8 to find undefined names in Python code

### DIFF
--- a/.github/workflows/tests2.yml
+++ b/.github/workflows/tests2.yml
@@ -11,10 +11,10 @@ jobs:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - run: python -m pip install nox==2020.5.24
-    - run: python -m pip install poetry==1.0.10
+    - run: python -m pip install flake8==3.8.3 nox==2020.5.24 poetry==1.0.10
+    - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - run: python -m nox

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -1,4 +1,4 @@
-from ciphey.LanguageChecker import LanguageChecker as lc
+from ciphey.LanguageChecker import LanguageChecker
 import unittest
 from loguru import logger
 


### PR DESCRIPTION

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.