### PR TITLE
Change all old documentation links to new ones

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,27 +2,27 @@ Howdy!
 
 So, you're interested in contributing to Ciphey? 🤔
 
-But maybe you're confused as to where to start, or you believe your coding skills aren't "good enough". Well, for the latter - that's ridiculous! We're perfectly okay with "bad code", and even then, if you're reading this document you're probably a great programmer. I mean, newbies don't often learn to contribute to GitHub projects 😉
+Perhaps you're confused as to where to start, or you believe your coding skills aren't "good enough"? Well, for the latter - that's ridiculous! We're perfectly okay with "bad code" and even then, if you're reading this document you're probably a great programmer. I mean, newbies don't often learn to contribute to GitHub projects 😉
 
 Here are some ways you can contribute to Ciphey:
 * Add a new language 🧏
 * Add more encryption methods 📚
-* Create more documentation (very important‼️  We would be eternally grateful)
+* Create more documentation (very important! We would be eternally grateful)
 * Fix bugs submitted via GitHub issues (we can support you in this 😊)
 * Refactor the code base 🥺
 
-If these sound hard, do not worry! This document will walk you through exactly how to achieve any of these. And also.... Your name will be added to Ciphey's contributors list, and we'll be eternally grateful! 🙏
+If these sound hard, do not worry! This document will walk you through exactly how to achieve any of these. Also, your name will be added to Ciphey's contributors list, and we'll be eternally grateful! 🙏
 
 
-We have a small Discord chat for you to talk to the developers and get some help. Alternatively, write a GitHub issue for your suggestion. If you want to be added to the Discord, DM us or ask us somehow.
+We have a small Discord chat for you to talk to the developers and get some help. Alternatively, you can write a GitHub issue for your suggestion. If you want to be added to the Discord, DM us or ask us somehow.
 
 [Discord Server](https://discord.gg/KfyRUWw)
 # How to contribute
 Ciphey is always in need of more decryption tools! To learn how to integrate code into ciphey, check out:
-* https://docs.ciphey.online/en/latest/makingCiphers.html for a simple tutorial
-* https://docs.ciphey.online/en/latest/extending.html for a API reference
+* https://github.com/Ciphey/Ciphey/wiki/Adding-your-own-ciphers for a simple tutorial
+* https://github.com/Ciphey/Ciphey/wiki/Extending-Ciphey for a API reference
 
-It'd be nice if you wrote some tests for it, by simply copying a function in the Ciphey/tests/test_main.py and replacing the ciphertext with something encoded with your cipher. If you don't add tests, we will probably still merge it, but it will be much harder for us to diagnose bugs!
+It would be nice if you wrote some tests for it, by simply copying a function in the Ciphey/tests/test_main.py and replacing the ciphertext with something encoded with your cipher. If you don't add tests, we will probably still merge it, but it will be much harder for us to diagnose bugs!
 
 It goes without saying that we will add you to the list of contributors for your hard work!
 
@@ -33,17 +33,17 @@ But honestly, all you've got to do is take a dictionary, do a little analysis (w
 # Create more documentation
 Documentation is the most important part of Ciphey. No documentation is extreme code debt, and we don't want that. 
 
-And trust me when I say, if you contribute to great documentation you will be seen on the same level as code contributors. Documentation is absolutely vital.
+Trust me when I say, if you contribute to great documentation you will be seen on the same level as code contributors. Documentation is absolutely vital.
 
-There's lots of ways you can add documentation.
+There are lots of ways you can add documentation.
 * Doc strings in the code
-* Improving our current documentation (README, this file, our Read The Docs pages)
+* Improving our current documentation (README, this file, our Ciphey Wiki pages)
 * Translating documentation
 
 And much more!
 
-# Fix Bugs
-Visit our GitHub issues page to find all the bugs Ciphey has! And squash them, you'll be added to the contributors list ;)
+# Fix bugs
+Visit our GitHub issues page to find all the bugs that Ciphey has! Squash them, and you'll be added to the contributors list. ;)
 
-# Refacor the code base
+# Refactor the code base
 Not all of Ciphey follows PEP8, and some of the code is repeated.

--- a/ciphey/ciphey.py
+++ b/ciphey/ciphey.py
@@ -5,7 +5,7 @@
 ██║     ██║██╔═══╝ ██╔══██║██╔══╝    ╚██╔╝  
 ╚██████╗██║██║     ██║  ██║███████╗   ██║ 
 https://github.com/ciphey
-https://docs.ciphey.online
+https://github.com/Ciphey/Ciphey/wiki
 
 The cycle goes:
 main -> argparsing (if needed) -> call_encryption -> new Ciphey object -> decrypt() -> produceProbTable ->
@@ -131,7 +131,7 @@ def main(**kwargs):
     """Ciphey - Automated Decryption Tool
     
     Documentation: 
-    https://docs.ciphey.online\n
+    https://github.com/Ciphey/Ciphey/wiki\n
     Discord (support here, we're online most of the day):
     https://discord.ciphey.online/\n
     GitHub: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "5.5.3"
 description = "Automated Decryption Tool"
 authors = ["Brandon <brandon@skerritt.blog>"]
 license = "MIT"
-documentation = "https://docs.ciphey.online"
+documentation = "https://github.com/Ciphey/Ciphey/wiki"
 exclude = ["tests/hansard.txt"]
 readme = "README.md"
 

--- a/translations/de/CONTRIBUTING.md
+++ b/translations/de/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Wir haben einen Discord-Server, in dem Du Kontakt zu den Entwicklerinnen & Entwi
 [Discord-Server](https://discord.gg/KfyRUWw)
 # Wie kann Ich beitragen?
 Ciphey braucht immer neue Entschlüsselungsmodule! Um herauszufinden, wie Du Deinen Code in Ciphey integrieren kannst, schau hier rein:
-* https://docs.ciphey.online/en/latest/makingCiphers.html für eine einfache Anleitung.
-* https://docs.ciphey.online/en/latest/extending.html für die API-Reference.
+* https://github.com/Ciphey/Ciphey/wiki/Adding-your-own-ciphers für eine einfache Anleitung.
+* https://github.com/Ciphey/Ciphey/wiki/Extending-Ciphey für die API-Reference.
 
 Es wäre toll, wenn Du ein paar Tests für Deinen Code schreiben könntest. Das ist ganz einfach: 
 Kopiere Deine Funktion nach Ciphey/tests/test_main.py und ersetze den `ciphertext` mit etwas, das mit Deiner Methode verschlüsselt wurde. Wir werden wahrscheinlich auch Code ohne Tests mergen, dieser ist aber schwerer zu debuggen.

--- a/translations/de/README.md
+++ b/translations/de/README.md
@@ -4,9 +4,9 @@
 <a href=https://github.com/Ciphey/Ciphey/tree/master/README.md>🇬🇧 EN   </a>
  <br><br>
 ➡️ 
-<a href="https://docs.ciphey.online">Dokumentation</a> |
+<a href="https://github.com/Ciphey/Ciphey/wiki">Dokumentation</a> |
 <a href="https://discord.ciphey.online">Discord</a> |
- <a href="https://docs.ciphey.online/en/latest/install.html">Installationshilfe</a>
+ <a href="https://github.com/Ciphey/Ciphey/wiki/Installation">Installationshilfe</a>
  ⬅️
 
 <br>
@@ -27,7 +27,7 @@ Vollautomatisiertes Entschlüsselungs-Tool, gestützt durch algorithmische Sprac
 </p>
 <hr>
 
-## [Installationshilfe](https://docs.ciphey.online/en/latest/install.html)
+## [Installationshilfe](https://github.com/Ciphey/Ciphey/wiki/Installation)
 
 | <p align="center"><a href="https://pypi.org/project/ciphey">🐍 Python | <p align="center"><a href="https://pypi.org/project/ciphey">🐋 Docker (Universell) |
 | --------------------------- | ---------------------------------|
@@ -117,13 +117,13 @@ Außerdem haben wir Ciphey und CyberChef mit einer **6GB Eingabedatei** gegenein
 
 # 🎬 Erste Schritte
 
-Bei Problemen bei der Installation von Ciphey, [hier weiterlesen.](https://docs.ciphey.online/en/latest/install.html)
+Bei Problemen bei der Installation von Ciphey, [hier weiterlesen.](https://github.com/Ciphey/Ciphey/wiki/Common-Issues-&-Their-Solutions)
 
 ## ‼️ Wichtige Links (Docs, Installationshilfe, Discord Support)
 
 | Installationshilfe | Dokumentation | Discord | Docker Image (von REMnux)
 | ------------------ | ------------- | ------- | ------- | 
-| 📖 [Installationshilfe](https://docs.ciphey.online/en/latest/install.html) | 📚 [Dokumentation](https://docs.ciphey.online) | 🦜 [Discord](https://discord.ciphey.online) | 🐋 [Docker Dokumentation](https://docs.remnux.org/run-tools-in-containers/remnux-containers#ciphey)
+| 📖 [Installationshilfe](https://github.com/Ciphey/Ciphey/wiki/Installation) | 📚 [Dokumentation](https://github.com/Ciphey/Ciphey/wiki) | 🦜 [Discord](https://discord.ciphey.online) | 🐋 [Docker Dokumentation](https://docs.remnux.org/run-tools-in-containers/remnux-containers#ciphey)
 
 ## 🏃‍♀️Ciphey ausführen
 Es gibt 3 Möglichkeiten, Ciphey auszuführen:

--- a/translations/hu/CONTRIBUTING.md
+++ b/translations/hu/CONTRIBUTING.md
@@ -19,8 +19,8 @@ Van egy kis Discord szerverünk, ahol beszélgethetsz a fejlesztőkkel, és seg�
 [Discord Server](https://discord.gg/KfyRUWw)
 # Hogy lehet hozzájárulni
 A Ciphey-nak mindig több dekódoló eszközre van szüksége! Ha meg szeretnéd tudni, hogyan integrálhatsz egy kódot a titkosításba, nézdd meg ezeket:
-* https://docs.ciphey.online/en/latest/makingCiphers.html Egyszerű példa
-* https://docs.ciphey.online/en/latest/extending.html API referencia
+* https://github.com/Ciphey/Ciphey/wiki/Adding-your-own-ciphers Egyszerű példa
+* https://github.com/Ciphey/Ciphey/wiki/Extending-Ciphey API referencia
 
 Jó lenne, ha néhány tesztet írnál rá, egyszerűen másolj át egy függvényt a Ciphey / tests / test_main.py fájlba, és cseréld le a rejtjelszöveget a titkosításával kódolt valamire. Ha nem adsz hozzá teszteket, valószínűleg továbbra is egyesítjük a kódot, de sokkal nehezebb lesz diagnosztizálnunk a hibákat!
 

--- a/translations/id/CONTRIBUTING.md
+++ b/translations/id/CONTRIBUTING.md
@@ -19,8 +19,8 @@ Kami memiliki Discord server kecil agar Anda dapat berbicara dengan pengembang C
 [Server Discord](https://discord.gg/KfyRUWw)
 # Bagaimana cara berkontribusi?
 Ciphey selalu membutuhkan lebih banyak alat dekripsi! Untuk mempelajari cara mengintegrasikan kode ke dalam ciphey, bacalah:
-* https://docs.ciphey.online/en/latest/makingCiphers.html untuk tutorial sederhana
-* https://docs.ciphey.online/en/latest/extending.html untuk referensi API
+* https://github.com/Ciphey/Ciphey/wiki/Adding-your-own-ciphers untuk tutorial sederhana
+* https://github.com/Ciphey/Ciphey/wiki/Extending-Ciphey untuk referensi API
 
 Akan lebih bagus jika anda bisa menulis beberapa test untuknya. Ini bisa dilakukan hanya dengan menyalin fungsi di Ciphey/tests/test_main.py dan menganti ciphertest dengan sesuatu yang dikodekan dengan cipher anda. Jika anda tidak menambahkan test, ada kemungkinan besar kami akan tetap menggabungkannya, tetapi akan lebih sulit bagi kamu untuk mendiagnosis bug!
 

--- a/translations/id/README.md
+++ b/translations/id/README.md
@@ -5,9 +5,9 @@ Terjemahan <br>
 <a href=https://github.com/Ciphey/Ciphey/tree/master/translations/de/README.md>🇩🇪 DE   </a>
  <br><br>
 ➡️ 
-<a href="https://docs.ciphey.online">Dokumentasi</a> |
+<a href="https://github.com/Ciphey/Ciphey/wiki">Dokumentasi</a> |
 <a href="https://discord.ciphey.online">Discord</a> |
- <a href="https://docs.ciphey.online/en/latest/install.html">Petunjuk Instalasi</a>
+ <a href="https://github.com/Ciphey/Ciphey/wiki/Installation">Petunjuk Instalasi</a>
  ⬅️
 
 <br>
@@ -28,7 +28,7 @@ Alat dekripsi otomatis yang menggunakan pemrosesan bahasa alami & kecerdasan bua
 </p>
 <hr>
 
-## [Petunjuk Instalasi](https://docs.ciphey.online/en/latest/install.html)
+## [Petunjuk Instalasi](https://github.com/Ciphey/Ciphey/wiki/Installation)
 
 | <p align="center"><a href="https://pypi.org/project/ciphey">🐍 Python | <p align="center"><a href="https://pypi.org/project/ciphey">🐋 Docker (Universal) |
 | --------------------------- | ---------------------------------|
@@ -56,11 +56,11 @@ Ciphey dapat mendekripsi kebanyakan hal dalam 3 detik atau kurang.
 
 **Detail teknis** Ciphey mengunakan modul kecerdasan buatan (_AuSearch_) dengan sebuah _Antarmuka Deteksi Cipher_ untuk memperkirakan enkripsi teks yang diberikan. Dan kemudian, sebuah _Antarmuka Pemerika Bahasa_ yang dibuat khusus dipakai untuk mendeteksi kapan teks yang diberikan sudah terdekripsi.
 
-Dan itu hanya baru puncak dari gunung es. Untuk penjelasan teknis yang lebih lengkap, lihat [dokumentasi](https://docs.ciphey.online/en/latest) kita.
+Dan itu hanya baru puncak dari gunung es. Untuk penjelasan teknis yang lebih lengkap, lihat [dokumentasi](https://github.com/Ciphey/Ciphey/wiki) kita.
 
 # ✨ Fitur-fitur
 
-- **Lebih dari 20 jenis enkripsi didukung** seperti penyandian (binary, base64) dan enkripsi normal seperti cipher Caesar, Transposisi dan banyak lagi. **[Untuk daftar lengkap, klik disini](https://docs.ciphey.online/en/latest/ciphers.html)**
+- **Lebih dari 20 jenis enkripsi didukung** seperti penyandian (binary, base64) dan enkripsi normal seperti cipher Caesar, Transposisi dan banyak lagi. **[Untuk daftar lengkap, klik disini](https://github.com/Ciphey/Ciphey/wiki/Supported-Ciphers)**
 - **Ciphey mengunakan modul kecerdasan buatan dengan Pencarian Bertambah (_AuSearch_) untuk menjawab pertanyaan "enkripsi apa yang digunakan?"** Ini memunkinkan dekripsi untuk membutuhkan waktu kurang dari 3 detik. 
 - **Modul pemrosesan bahasa alami yang dibangun khusus** Ciphey dapat mendeteksi ketika sesuatu adalah teks biasa dengan akurasi yang sangat tinggi dan dengan cepat.
 - **Dukungan Multi Bahasa** saat ini, hanya Bahasa Jerman & Inggris (dengan varian AU, UK, CAN, USA) yang tersedia.
@@ -117,13 +117,13 @@ Kami juga menguji CyberChef dan Ciphey dengan file sebesar **6gb**. Ciphey memec
 
 # 🎬 Getting Started
 
-If you're having trouble with installing Ciphey, [read this.](https://docs.ciphey.online/en/latest/install.html)
+If you're having trouble with installing Ciphey, [read this.](https://github.com/Ciphey/Ciphey/wiki/Common-Issues-&-Their-Solutions)
 
 ## ‼️ Important Links (Docs, Installation guide, Discord Support)
 
 | Petunjuk Instalasi | Dokumentasi | Discord |
 | ------------------ | ------------- | ------- |
-| 📖 [Petunjuk Instalasi](https://docs.ciphey.online/en/latest/install.html) | 📚 [Dokumentasi](https://docs.ciphey.online) | 🦜 [Discord](https://discord.ciphey.online)
+| 📖 [Petunjuk Instalasi](https://github.com/Ciphey/Ciphey/wiki/Installation) | 📚 [Dokumentasi](https://github.com/Ciphey/Ciphey/wiki) | 🦜 [Discord](https://discord.ciphey.online)
 
 ## 🏃‍♀️Menggunakan Ciphey
 Ada 3 cara untuk memakai Ciphey.


### PR DESCRIPTION
There was still some links leading to the old documentation website, so I switched them to the new Ciphey wiki.