### PR TITLE
Grammar fix for Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ And that's just the tip of the iceberg. For the full technical explanation, chec
 
 - **30+ encryptions supported** such as encodings (binary, base64) and normal encryptions like Caesar cipher, repeating-key XOR and more. **[For the full list, click here](https://github.com/Ciphey/Ciphey/wiki/Supported-Ciphers)**
 - **Custom Built Artificial Intelligence with Augmented Search (AuSearch) for answering the question "what encryption was used?"** Resulting in decryptions taking less than 3 seconds. 
-- **Custom built natural language processing module** Ciphey can determine whether something is plaintext or not. Whether that plaintext is JSON, a CTF flag or English Ciphey can get it in a couple of milliseconds.
+- **Custom built natural language processing module** Ciphey can determine whether something is plaintext or not. Whether that plaintext is JSON, a CTF flag, or English, Ciphey can get it in a couple of milliseconds.
 - **Multi Language Support** at present, only German & English (with AU, UK, CAN, USA variants).
 - **Supports encryptions and hashes** Which the alternatives such as CyberChef Magic do not. 
 - **[C++ core](https://github.com/Ciphey/CipheyCore)** Blazingly fast.


### PR DESCRIPTION
`Whether that plaintext is JSON, a CTF flag, or English, Ciphey can get it in a couple of milliseconds.` was previously somewhat unclear. I have added commas to improve the clarity.