### PR TITLE
Support Python 3.9 (Fix #558)

### DIFF
--- a/.github/workflows/terminaltest.yml
+++ b/.github/workflows/terminaltest.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests2.yml
+++ b/.github/workflows/tests2.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9']
         os: [ubuntu-latest, windows-latest] #macos-latest,
     runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/ciphey/iface/_modules.py
+++ b/ciphey/iface/_modules.py
@@ -205,8 +205,10 @@ class DecoderComparer:
         return f"<DecoderComparer {self.value}:{self.value.priority()}>"
 
 
-class CrackResult(NamedTuple, Generic[T]):
-    value: T
+class CrackResult(NamedTuple):
+    # TODO consider using Generic[T] again for value's type once
+    # https://bugs.python.org/issue36517 is resolved
+    value: Any
     key_info: Optional[str] = None
     misc_info: Optional[str] = None
 


### PR DESCRIPTION
This issue was already raised on https://bugs.python.org/issue36517,
adding a TODO to consider going back to Generic[T] once this is solved.

Tested `python -m ciphey -t "aGVsbG8gbXkgbmFtZSBpcyBiZWU="` on Python 3.9, and it works with this fix.