### PR TITLE
Added linking & description to Cipheys pywhat

### DIFF
--- a/ciphey/basemods/Checkers/what.py
+++ b/ciphey/basemods/Checkers/what.py
@@ -20,10 +20,28 @@ class What(Checker[str]):
         logger.trace("Trying PyWhat checker")
         returned_regexes = self.id.identify(ctext, api=True)
         if len(returned_regexes["Regexes"]) > 0:
-            console.print(
-                f'\nI think the plaintext is a [yellow]{returned_regexes["Regexes"][0]["Regex Pattern"]["Name"]}[/yellow].'
-            )
-            return f'The plaintext is a [yellow]{returned_regexes["Regexes"][0]["Regex Pattern"]["Name"]}[/yellow].'
+
+            matched_regex = returned_regexes["Regexes"][0]["Regex Pattern"]
+
+            ret = f'The plaintext is a [yellow]{matched_regex["Name"]}[/yellow]'
+            human = f'\nI think the plaintext is a [yellow]{matched_regex["Name"]}[/yellow]'
+
+            if "Description" in matched_regex and matched_regex["Description"]:
+                s = matched_regex['Description']
+                # lowercases first letter so it doesn't look weird
+                s = f", which is {s[0].lower() + s[1:]}"
+                ret += s
+                human += s
+            
+            # Print with full stop
+            console.print(human)
+            
+            # if URL is attached, include that too.
+            if "URL" in matched_regex:
+                link = matched_regex['URL'] + ctext.replace(' ', '')
+                ret += f"\nClick here to view in browser [#CAE4F1][link={link}]{link}[/link][/#CAE4F1]"
+
+            return ret
         return None
 
     def getExpectedRuntime(self, text: T) -> float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ciphey"
-version = "5.11.3"
+version = "5.12.1"
 description = "Automated Decryption Tool"
 authors = ["Brandon <brandon@skerritt.blog>"]
 license = "MIT"
@@ -25,7 +25,7 @@ click = ">=7.1.2,<9.0.0"
 click-spinner = "^0.1.10"
 pyyaml = "^5.3.1"
 yaspin = ">=0.17,<1.6"
-pywhat = "^0.2.5"
+pywhat = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.10.1"

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -1,0 +1,14 @@
+from click.testing import CliRunner
+from ciphey.ciphey import main
+
+def test_hello_world():
+  runner = CliRunner()
+  result = runner.invoke(main, ['-g', '-t', 'hello'])
+  assert result.exit_code == 0
+  assert result.output == 'hello\n'
+
+def test_ip_address():
+  runner = CliRunner()
+  result = runner.invoke(main, ['-g', '-t', 'MTkyLjE2OC4wLjE='])
+  assert result.exit_code == 0
+  assert result.output == '192.168.0.1\n'


### PR DESCRIPTION
* Descriptions only appear if the regex has it. We only have 2 regex with descriptions.
* Descriptions with links are embedded as hyperlinks, this doesn't work on CMD but tbh microsoft is slowly moving to Windows Terminal and who really cares if the link works.
* Descriptions are "naturalised" so they have a lowercase first letter and end with a full stop.
* Regex with URLs are shown too, they use both Rich hyperlinking and just printing the URL.
These regex are rare. The idea is that if someone comes across lat / long coords, their next stop is Google Maps. We can take them directly there, eliminating the middleman and improving user experience.

Unfortunately due to iface I can only show links at the checkers returned level, not near the plaintext :-(]

![image](https://user-images.githubusercontent.com/10378052/119255591-8bddac00-bbb4-11eb-90b1-b82e996b0cfa.png)
![image](https://user-images.githubusercontent.com/10378052/119255633-c3e4ef00-bbb4-11eb-8fff-7aa0cfd57e2e.png)

Note: In the next version of `pywhat` the wikipedia link is turned into a hyperlink, so it's not as ugly.

PS: I don't know why the 2nd link isn't coming up as blue, but when we move to hyperlinks in https://github.com/bee-san/pyWhat/pull/32 it should be okay :-) 