### PR TITLE
Greppable mode no longer triggers whats printing

### DIFF
--- a/ciphey/basemods/Checkers/what.py
+++ b/ciphey/basemods/Checkers/what.py
@@ -20,9 +20,11 @@ class What(Checker[str]):
         logger.trace("Trying PyWhat checker")
         returned_regexes = self.id.identify(ctext, api=True)
         if len(returned_regexes["Regexes"]) > 0:
-            console.print(
-                f'\nI think the plaintext is a [yellow]{returned_regexes["Regexes"][0]["Regex Pattern"]["Name"]}[/yellow].'
-            )
+            # If greppable mode is on, don't print this
+            if self.config.verbosity > 0:
+                console.print(
+                    f'\nI think the plaintext is a [yellow]{returned_regexes["Regexes"][0]["Regex Pattern"]["Name"]}[/yellow].'
+                )
             return f'The plaintext is a [yellow]{returned_regexes["Regexes"][0]["Regex Pattern"]["Name"]}[/yellow].'
         return None
 
@@ -36,4 +38,5 @@ class What(Checker[str]):
 
     def __init__(self, config: Config):
         super().__init__(config)
+        self.config = config
         self.id = identifier.Identifier()


### PR DESCRIPTION
With greppable mode on, `what` still prints the regex info.

This fixes that :)