### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/tests2.yml
+++ b/.github/workflows/tests2.yml
@@ -15,7 +15,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - run: python -m pip install codespell==2.1.0 flake8==3.9.2 nox==2020.5.24 poetry==1.0.10
+    - run: python -m pip install --upgrade pip
+    - run: pip install codespell==2.1.0 flake8==3.9.2 nox==2021.6.12 poetry==1.0.10
     - run: codespell --ignore-words-list="nd,te" --skip="translations,*.archive"
     - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - run: python -m nox

--- a/.github/workflows/tests2.yml
+++ b/.github/workflows/tests2.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - run: python -m pip install flake8==3.8.3 nox==2020.5.24 poetry==1.0.10
+    - run: python -m pip install codespell==2.1.0 flake8==3.9.2 nox==2020.5.24 poetry==1.0.10
+    - run: codespell --ignore-words-list="nd,te" --skip="translations,*.archive"
     - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - run: python -m nox

--- a/ciphey/basemods/Searchers/atar.md
+++ b/ciphey/basemods/Searchers/atar.md
@@ -143,7 +143,7 @@ function calculate_new_children(node):
     
 class Node:
     """
-    A node has a value assiocated with it
+    A node has a value associated with it
     Calculated from the heuristic
     """
 

--- a/ciphey/basemods/Searchers/imperfection.py
+++ b/ciphey/basemods/Searchers/imperfection.py
@@ -5,7 +5,7 @@ class Imperfection:
     """The graph is a Node: [List of nodes]
     Where each item in the list of nodes can also have a node with a list of nodes
 
-    Ths result is that we can keep track of edges, while also keeping it small
+    The result is that we can keep track of edges, while also keeping it small
 
     To calculate current, we push the entire graph to A*
 

--- a/ciphey/ciphey.py
+++ b/ciphey/ciphey.py
@@ -40,7 +40,7 @@ def decrypt(config: iface.Config, ctext: Any) -> Union[str, bytes]:
 
 
 def get_name(ctx, param, value):
-    # reads from stdin if the argument wasnt supplied
+    # reads from stdin if value was not supplied
     if not value and not click.get_text_stream("stdin").isatty():
         click.get_text_stream("stdin").read().strip()
         return click.get_text_stream("stdin").read().strip()


### PR DESCRIPTION
[`codespell --ignore-words-list="nd,te" --skip="translations,*.archive"`](https://pypi.org/project/codespell)