### PR TITLE
Add timeout functionality to terminate processes after 60 seconds.

### DIFF
--- a/ciphey/__main__.py
+++ b/ciphey/__main__.py
@@ -6,6 +6,7 @@ Ciphey: https://github.com/Ciphey/Ciphey
 
 import platform
 import sys
+from multiprocessing import Process
 
 if __name__ == "__main__":
     major = sys.version_info[0]
@@ -39,6 +40,14 @@ if __name__ == "__main__":
                 "You are using Python 32 bit and Windows, Ciphey does not support this. Please upgrade to Python 64-bit here https://www.python.org/downloads/"
             )
             sys.exit(1)
+
     from .ciphey import main
 
-    main()
+    m = Process(target=main, name="process_main")
+    m.start()
+    # Set timeout at 60 seconds
+    m.join(timeout=60)
+    m.terminate()
+
+    if m.exitcode is None:
+        print("Could not find any solutions.")

--- a/ciphey/ciphey.py
+++ b/ciphey/ciphey.py
@@ -97,6 +97,12 @@ def print_help(ctx):
     "--searcher",
     help="Select the searching algorithm to use",
 )
+
+@click.option(
+    "--timeout",
+    help="Set the timeout in seconds (default 60)"
+)
+
 # HARLAN TODO XXX
 # I switched this to a boolean flag system
 # https://click.palletsprojects.com/en/7.x/options/#boolean-flags


### PR DESCRIPTION
# Patch for #743
## Summary
Previously, the software was not timing out after a period of inactivity. I have added this functionally using the multiprocessing library. The timeout is currently hard-coded at 60 seconds, but I have added a flag to [ciphey.py](https://github.com/Ciphey/Ciphey/blob/master/ciphey/ciphey.py) which can be incorporated.

## TODO
- Enable `--timeout` flag in [ciphey.py](https://github.com/Ciphey/Ciphey/blob/master/ciphey/ciphey.py) (currently unused).

`This PR is part of my Hacktoberfest contribution.`