### PR TITLE
Add Citrix CTX1 decoder

### DIFF
--- a/ciphey/basemods/Decoders/__init__.py
+++ b/ciphey/basemods/Decoders/__init__.py
@@ -11,6 +11,7 @@ from . import (
     binary,
     braille,
     brainfuck,
+    citrix_ctx1,
     decimal,
     dna,
     dtmf,

--- a/ciphey/basemods/Decoders/citrix_ctx1.py
+++ b/ciphey/basemods/Decoders/citrix_ctx1.py
@@ -1,0 +1,46 @@
+# community
+# by https://github.com/mklarz
+
+from typing import Optional, Dict 
+
+from ciphey.iface import ParamSpec, Config, T, U, Decoder, registry
+
+
+@registry.register
+class Citrix_ctx1(Decoder[str]):
+    def decode(self, ctext: T) -> Optional[U]:
+        if len(ctext) % 4 != 0:
+            return None
+
+        rev = ctext[::-1].encode()
+        result = b""
+        temp = 0
+
+        for i in range(0, len(rev), 2):
+            if i + 2 >= len(rev):
+                temp = 0
+            else:
+                temp = ((rev[i + 2] - 0x41) & 0xF) ^ (((rev[i + 3] - 0x41) << 4) & 0xF0)
+            temp = (
+                (((rev[i] - 0x41) & 0xF) ^ (((rev[i + 1] - 0x41) << 4) & 0xF0))
+                ^ 0xA5
+                ^ temp
+            )
+            result += bytes([temp])
+
+        return result.replace(b"\x00", b"")[::-1]
+
+    @staticmethod
+    def priority() -> float:
+        return 0.01
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+
+    @staticmethod
+    def getParams() -> Optional[Dict[str, ParamSpec]]:
+        pass
+
+    @staticmethod
+    def getTarget() -> str:
+        return "citrix_ctx1"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -180,6 +180,14 @@ def test_caesar():
     assert res == answer_str
 
 
+def test_citrix_ctx1():
+    res = decrypt(
+        Config().library_default().complete_config(),
+        "ONEIIICNOEEBIICNOHECMHGCKKAPNDHGPDFGJNDIPMFJJBDEPEFBNEHBLNBIMOGLOOELIMCJOJEMIMCJKMAJMNGIKDAGMHGCOHECKOALIOCLOCEHILCOOAEFIFCAKFAAMBGEKOALMJGMOJEMIICNOGEDICCHKCAHMDGGLDBGMDGGKPAKMKGPOKEPILCOOFEAIBCEKBAENFHAKHACMCGHKHAC"
+        )
+    assert res == answer_str
+
+
 def test_decimal():
     res = decrypt(
         Config().library_default().complete_config(),


### PR DESCRIPTION
Ported from [CyberChef](https://github.com/gchq/CyberChef/blob/a3b873fd96111fe2dbcb62a1e037987669290a13/src/core/operations/CitrixCTX1Decode.mjs), more information about the encoding itself can be found [here](https://www.remkoweijnen.nl/blog/2012/05/13/encoding-and-decoding-citrix-passwords/).