### PR TITLE
Add --output option to save decrypted text to a file (Closes #805)

### DIFF
--- a/ciphey/ciphey.py
+++ b/ciphey/ciphey.py
@@ -101,7 +101,7 @@ def print_help(ctx):
     "-o",
     "--output",
     help="Specify the path to save the output to a text file. Currently works only with quiet mode.",
-    type=str
+    type=str,
 )
 # HARLAN TODO XXX
 # I switched this to a boolean flag system
@@ -275,5 +275,6 @@ def main(**kwargs):
     if "output" in kwargs and kwargs["output"]:
         with open(kwargs["output"], "w") as file:
             file.write(result)
+
     else:
         console.print(result)

--- a/ciphey/ciphey.py
+++ b/ciphey/ciphey.py
@@ -97,6 +97,12 @@ def print_help(ctx):
     "--searcher",
     help="Select the searching algorithm to use",
 )
+@click.option(
+    "-o",
+    "--output",
+    help="Specify the path to save the output to a text file. Currently works only with quiet mode.",
+    type=str
+)
 # HARLAN TODO XXX
 # I switched this to a boolean flag system
 # https://click.palletsprojects.com/en/7.x/options/#boolean-flags
@@ -265,4 +271,9 @@ def main(**kwargs):
     if result is None:
         result = "Could not find any solutions."
 
-    console.print(result)
+    # if output path is specified, save the output to the file
+    if "output" in kwargs and kwargs["output"]:
+        with open(kwargs["output"], "w") as file:
+            file.write(result)
+    else:
+        console.print(result)

--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/tests/test_output_file.py
+++ b/tests/test_output_file.py
@@ -6,23 +6,15 @@ from ciphey.ciphey import main
 def test_output_to_file():
     runner = CliRunner()
     test_output_path = "test_output.txt"
-    
-    # Run Ciphey with a sample text and specify the output file path
     result = runner.invoke(main, ["-t", "aGVsbG8gd29ybGQ=", "-q", "-o", test_output_path])
-    
-    # Check if the file was created and contains output
     assert os.path.exists(test_output_path), "Output file was not created"
     with open(test_output_path, "r") as f:
         content = f.read()
     assert "hello world" in content, "Decrypted output was not saved correctly"
-    
-    # Clean up the test output file
     os.remove(test_output_path)
 
 def test_output_to_console():
     runner = CliRunner()
     result = runner.invoke(main, ["-t", "aGVsbG8gd29ybGQ="])
-    
-    # Check that the console output contains the decrypted text
     assert "hello world" in result.output, "Decrypted output was not printed to console"
 

--- a/tests/test_output_file.py
+++ b/tests/test_output_file.py
@@ -3,18 +3,21 @@ import pytest
 from click.testing import CliRunner
 from ciphey.ciphey import main
 
+
 def test_output_to_file():
     runner = CliRunner()
     test_output_path = "test_output.txt"
-    result = runner.invoke(main, ["-t", "aGVsbG8gd29ybGQ=", "-q", "-o", test_output_path])
+    result = runner.invoke(
+        main, ["-t", "aGVsbG8gd29ybGQ=", "-q", "-o", test_output_path]
+    )
     assert os.path.exists(test_output_path), "Output file was not created"
     with open(test_output_path, "r") as f:
         content = f.read()
     assert "hello world" in content, "Decrypted output was not saved correctly"
     os.remove(test_output_path)
 
+
 def test_output_to_console():
     runner = CliRunner()
     result = runner.invoke(main, ["-t", "aGVsbG8gd29ybGQ="])
     assert "hello world" in result.output, "Decrypted output was not printed to console"
-

--- a/tests/test_output_file.py
+++ b/tests/test_output_file.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+from click.testing import CliRunner
+from ciphey.ciphey import main
+
+def test_output_to_file():
+    runner = CliRunner()
+    test_output_path = "test_output.txt"
+    
+    # Run Ciphey with a sample text and specify the output file path
+    result = runner.invoke(main, ["-t", "aGVsbG8gd29ybGQ=", "-q", "-o", test_output_path])
+    
+    # Check if the file was created and contains output
+    assert os.path.exists(test_output_path), "Output file was not created"
+    with open(test_output_path, "r") as f:
+        content = f.read()
+    assert "hello world" in content, "Decrypted output was not saved correctly"
+    
+    # Clean up the test output file
+    os.remove(test_output_path)
+
+def test_output_to_console():
+    runner = CliRunner()
+    result = runner.invoke(main, ["-t", "aGVsbG8gd29ybGQ="])
+    
+    # Check that the console output contains the decrypted text
+    assert "hello world" in result.output, "Decrypted output was not printed to console"
+


### PR DESCRIPTION
This PR adds a new command-line option `--output` (`-o`) to specify a file path for saving decrypted text, addressing the enhancement requested in #805.
#### Summary of Changes:
- **New --output Option**: Users can now specify a file path with `-o` or `--output` to save the decrypted output directly to a text file.
- **Functionality Update:**
  - If `--output` is provided, the result is saved to the specified file.
  - If no output file is provided, the result prints to the console as usual.

- **Tests Added**:
  - **Output to file**: Verifies that output is correctly saved to a file.
  - **Console output**: Ensures standard console output works when no file is specified.

- This PR closes #805.
- ### **Currently the --output option only works with the --quiet option.**

> ciphey -t "aGVsbG8gbXkgbmFtZSBpcyBiZWU=" -q -o "output_file_path"

#### Notes for Reviewers
- Please review the integration of `--output` in the `main` function, as well as test cases covering various scenarios for this new option.
- Any suggestions for additional test cases are welcome.
